### PR TITLE
Add scripts to autoadd CPython

### DIFF
--- a/helpers/add-python.sh
+++ b/helpers/add-python.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+for versionFull in "$@"; do
+
+	semver=( ${versionFull//./ } )
+	vMajor="${semver[0]}"
+	vMinor="${semver[1]}"
+	vPatch="${semver[2]}"
+
+	curl -sSL "https://www.python.org/ftp/python/${versionFull}/Python-${versionFull}.tar.xz" -o /tmp/python.tar.xz
+	curl -sSL "https://www.python.org/ftp/python/${versionFull}/Python-${versionFull}.tgz" -o /tmp/python.tgz
+
+	gzHash=$( sha256sum /tmp/python.tgz | cut -d " " -f 1 )
+	xzHash=$( sha256sum /tmp/python.tar.xz | cut -d " " -f 1 )
+
+	sed -e 's/%%VERSION%%/'"$versionFull"'/g' "./helpers/template" > "./plugins/python-build/share/python-build/$versionFull"
+	sed -i.bak 's/%%MINOR%%/'"${vMajor}${vMinor}"'/g' "./plugins/python-build/share/python-build/${versionFull}"
+	sed -i.bak 's!%%XZHASH%%!'"${xzHash}"'!g' "./plugins/python-build/share/python-build/${versionFull}"
+	sed -i.bak 's!%%GZHASH%%!'"${gzHash}"'!g' "./plugins/python-build/share/python-build/${versionFull}"
+
+	# This .bak thing above and below is a Linux/macOS compatibility fix
+	rm "./plugins/python-build/share/python-build/${versionFull}.bak"
+done

--- a/helpers/template
+++ b/helpers/template
@@ -1,0 +1,10 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-%%VERSION%%" "https://www.python.org/ftp/python/%%VERSION%%/Python-%%VERSION%%.tar.xz#%%XZHASH%%" standard verify_py%%MINOR%% copy_python_gdb ensurepip
+else
+  install_package "Python-%%VERSION%%" "https://www.python.org/ftp/python/%%VERSION%%/Python-%%VERSION%%.tgz#%%GZHASH%%" standard verify_py%%MINOR%% copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
This adds a script that will automatically add one or more versions of CPython to Pungi/pyenv. The script is designed to be run from the root of the repo, which each version of CPython listed out, separated by spaces.