### PR TITLE
Accept `python3` in bats tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,7 @@ jobs:
       - bats/install
       - run:
           name: "Run Bats Tests"
-          command: |
-            sudo apt install python-is-python3
-            bats test
+          command: bats test
   install-python:
     parameters:
       python-version:

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -37,6 +37,7 @@ OUT
 }
 
 @test "prefix for invalid system" {
-  PATH="$(path_without python)" run pungi-prefix system
+  PATH="$(path_without python)"
+  PATH="$(path_without python3)" run pungi-prefix system
   assert_failure "pungi: system version not found in PATH"
 }

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -25,7 +25,8 @@ stub_system_python() {
 }
 
 @test "not even system python available" {
-  PATH="$(path_without python)" run pungi-versions
+  PATH="$(path_without python)"
+  PATH="$(path_without python3)" run pungi-versions
   assert_failure
   assert_output "Warning: no Python detected on the system"
 }


### PR DESCRIPTION
Tests should pass when only `python3` is available as system Python.

Fixes #4.