### PR TITLE
Allow setting global when installing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
               # Simplified SemVer regex
               only: /^v\d+\.\d+\.\d+$/
           matrix:
+            alias: install-python-generic
             parameters:
               python-version:
                 - 2.7.18
@@ -27,9 +28,26 @@ workflows:
                 - "18.04"
           requires:
             - shell-tests
+      - install-python:
+          filters:
+            tags:
+              # Simplified SemVer regex
+              only: /^v\d+\.\d+\.\d+$/
+          matrix:
+            alias: install-python-extra
+            parameters:
+              python-version:
+                - 2.7.18
+                - 3.9.5
+              ubuntu-version:
+                - "20.04"
+          extra: true
+          requires:
+            - shell-tests
       - release:
           requires:
-            - install-python
+            - install-python-generic
+            - install-python-extra
           filters:
             branches:
               ignore: /.*/
@@ -90,6 +108,9 @@ jobs:
         type: string
       ubuntu-version:
         type: string
+      extra:
+        type: boolean
+        default: false
     docker:
       - image: cimg/base:2021.07-<< parameters.ubuntu-version >>
     steps:
@@ -103,8 +124,14 @@ jobs:
               DIRECT="--direct"
               echo "Installing Python using the --direct flag"
             fi
-            pungi install $DIRECT << parameters.python-version >>
-            pungi global << parameters.python-version >>
+            if [[ << parameters.extra >> ]];then
+              GLOBAL="--global"
+              echo "Installing Python using the --global flag"
+            fi
+            pungi install $DIRECT $GLOBAL << parameters.python-version >>
+            if [[ << parameters.extra >> ]];then
+              pungi global << parameters.python-version >>
+            fi
       - run:
           name: "Test Python version"
           command: python --version 2>&1 | grep "<< parameters.python-version >>"

--- a/plugins/python-build/bin/pungi-install
+++ b/plugins/python-build/bin/pungi-install
@@ -3,6 +3,7 @@
 # Summary: Install a Python version using python-build
 #
 # Usage: pungi install [-f] [-kvpd] <version>
+#        pungi install --global <version>
 #        pungi install [-f] [-kvpd] <definition-file>
 #        pungi install -l|--list
 #        pungi install --version
@@ -10,6 +11,7 @@
 #   -l/--list          List all available versions
 #   -f/--force         Install even if the version appears to be installed already
 #   -s/--skip-existing Skip if the version appears to be installed already
+#   --global           After installing, set as global version
 #
 #   python-build options:
 #
@@ -48,6 +50,7 @@ if [ "$1" = "--complete" ]; then
   echo --version
   echo --debug
   echo --direct
+  echo --global
   exec python-build --definitions
 fi
 
@@ -75,6 +78,7 @@ unset VERBOSE
 unset HAS_PATCH
 unset DEBUG
 unset DIRECT
+unset GLOBAL
 
 parse_options "$@"
 for option in "${OPTIONS[@]}"; do
@@ -110,6 +114,9 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "d" | "direct" )
     DIRECT="-d"
+    ;;
+  "global" )
+    GLOBAL=true
     ;;
   * )
     usage 1 >&2
@@ -288,6 +295,11 @@ if [ "$STATUS" == "0" ]; then
   pungi-rehash
 else
   cleanup
+fi
+
+# Optionally set the newly installed Python version
+if [[ $GLOBAL ]]; then
+  pungi-global $DEFINITION
 fi
 
 exit "$STATUS"


### PR DESCRIPTION
This PR introduced the `--global` flag to pungi install. This allows you to install a Python version and then immediately set it as the global version.