### PR TITLE
Feat: system should show version

### DIFF
--- a/libexec/pungi-versions
+++ b/libexec/pungi-versions
@@ -105,21 +105,37 @@ exists() {
 
 print_version() {
   if [[ ${BASH_VERSINFO[0]} -ge 4 && ${current_versions["$1"]} ]]; then
-    echo "${hit_prefix}$1 (set by $(pungi-version-origin))"
+    echo "${hit_prefix}$1$2 (set by $(pungi-version-origin))"
   elif (( ${BASH_VERSINFO[0]} <= 3 )) && exists "$1" "${current_versions[@]}"; then
-    echo "${hit_prefix}$1 (set by $(pungi-version-origin))"
+    echo "${hit_prefix}$1$2 (set by $(pungi-version-origin))"
   else
-    echo "${miss_prefix}$1"
+    echo "${miss_prefix}$1$2"
   fi
   num_versions=$((num_versions + 1))
 }
 
 # Include "system" in the non-bare output, if it exists
 if [ -n "$include_system" ] && \
-    (PUNGI_VERSION=system pungi-which python >/dev/null 2>&1 || \
-     PUNGI_VERSION=system pungi-which python3 >/dev/null 2>&1 || \
-     PUNGI_VERSION=system pungi-which python2 >/dev/null 2>&1) ; then
-  print_version system
+	(PUNGI_VERSION=system pungi-which python >/dev/null 2>&1 || \
+	PUNGI_VERSION=system pungi-which python3 >/dev/null 2>&1 || \
+	PUNGI_VERSION=system pungi-which python2 >/dev/null 2>&1) ; then
+
+		VER=$( python --version 2>/dev/null )
+		if [[ ! -z $VER ]]; then
+			print_version system "-${VER:7}"
+		else
+
+			VER=$( python3 --version 2>/dev/null )
+			if [[ ! -z $VER ]]; then
+				print_version system "-${VER:7}"
+			else
+
+				VER=$( python2 --version 2>/dev/null )
+				if [[ ! -z $VER ]]; then
+					print_version system "-${VER:7}"
+				fi
+			fi
+		fi
 fi
 
 shopt -s dotglob nullglob

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -14,14 +14,16 @@ setup() {
 stub_system_python() {
   local stub="${PUNGI_TEST_DIR}/bin/python"
   mkdir -p "$(dirname "$stub")"
-  touch "$stub" && chmod +x "$stub"
+  echo '#!/usr/bin/env bash' > "$stub"
+  echo 'echo "Python 3.10.0"' >> "$stub"
+  chmod +x "$stub"
 }
 
 @test "no versions installed" {
   stub_system_python
   assert [ ! -d "${PUNGI_ROOT}/versions" ]
   run pungi-versions
-  assert_success "* system (set by ${PUNGI_ROOT}/version)"
+  assert_success "* system-3.10.0 (set by ${PUNGI_ROOT}/version)"
 }
 
 @test "not even system python available" {
@@ -42,7 +44,7 @@ stub_system_python() {
   run pungi-versions
   assert_success
   assert_output <<OUT
-* system (set by ${PUNGI_ROOT}/version)
+* system-3.10.0 (set by ${PUNGI_ROOT}/version)
   3.3
 OUT
 }
@@ -61,7 +63,7 @@ OUT
   run pungi-versions
   assert_success
   assert_output <<OUT
-* system (set by ${PUNGI_ROOT}/version)
+* system-3.10.0 (set by ${PUNGI_ROOT}/version)
   2.7.6
   3.3.3
   3.4.0
@@ -75,7 +77,7 @@ OUT
   PUNGI_VERSION=3.3.3 run pungi-versions
   assert_success
   assert_output <<OUT
-  system
+  system-3.10.0
 * 3.3.3 (set by PUNGI_VERSION environment variable)
   3.4.0
 OUT
@@ -100,7 +102,7 @@ OUT
   run pungi-versions
   assert_success
   assert_output <<OUT
-  system
+  system-3.10.0
 * 3.3.3 (set by ${PUNGI_ROOT}/version)
   3.4.0
 OUT
@@ -114,7 +116,7 @@ OUT
   run pungi-versions
   assert_success
   assert_output <<OUT
-  system
+  system-3.10.0
 * 3.3.3 (set by ${PUNGI_TEST_DIR}/.python-version)
   3.4.0
 OUT


### PR DESCRIPTION
Closes #15.

In a command like `pungi versions` where `system` can be displayed as a version, display what version system actually is. It will show something like `system-3.10.0`.